### PR TITLE
Draft: demonstrate an event-only model

### DIFF
--- a/example-client/client.py
+++ b/example-client/client.py
@@ -68,56 +68,72 @@ def run_structure(input: str) -> Optional[str]:
 
     received_event_ids = set()  # Keep track of which events we've already received.
     structure_has_terminal_event = False
-    
+
     # The client will continuously poll the Structure Run until it receives one of three events:
     # 1. Our Structure has voluntarily emitted a FinishStructureRunEvent
     # 2. The Structure has stopped running due to an error
     # 3. The Structure has stopped running without an error
     while not structure_has_terminal_event:
+        # TODO: Can the API be adjusted to give us all NEW events that occurred after a specific point?
         event_list = get_structure_run_events(
             host=HOST, api_key=GT_API_KEY, run_id=structure_run_id
         )
         events = event_list["events"]
-        
-        # Find all events that are new to us.      
+
+        # Find all events that are new to us.
         for event in events:
             event_id = event["event_id"]
             if event_id not in received_event_ids:
                 # Mark it as received.
                 received_event_ids.add(event_id)
-                
+
                 # Is this an event type that we care about?
                 event_type = event["value"]["type"]
-                
+
                 match event_type:
                     case "CompletionChunkEvent":
                         # If the agent is set to streaming, print out each streaming chunk
                         completion_token = event["value"]["token"]
                         print(completion_token, flush=True, end="")
                     case "FinishStructureRunEvent":
-                        
-                              
+                        # Our Griptape Structure told us that it was done, and gave us a payload for the output. Our client can stop polling the Structure.
+                        structure_has_terminal_event = True
+                        structure_output = event["value"]["output_task_output"]
+                        print(structure_output)
+                    case "SystemEvent.StructureRunExecutionFailed":
+                        # The system running our Griptape Structure reported that our code encountered an error. The client does not need to poll any further.
+                        structure_has_terminal_event = True
+                        errors = event["value"]["error messages"]
+                        raise ValueError(errors)
+                    case "SystemEvent.StructureRunExecutionSucceeded":
+                        # The system running our Griptape Structure reported that our code completed execution without erros. The client does not need to poll any further.
+                        structure_has_terminal_event = True
+                    case _:
+                        # All other event types land here.
+                        pass
 
         time.sleep(1)  # Poll every second.
 
-    logs = get_structure_run_logs(
-        host=HOST, api_key=GT_API_KEY, run_id=structure_run_id
-    )
 
-    if structure_run["status"] == "SUCCEEDED":
-        stdout = next(
-            (log["message"] for log in logs["logs"] if log["stream"] == "stdout"),
-            None,
-        )
-        print(stdout)
+# TODO: Today, logs take a long time to get, which kind of makes this code less useful. Could this info be put into the SystemEvents?
+#    logs = get_structure_run_logs(
+#        host=HOST, api_key=GT_API_KEY, run_id=structure_run_id
+#    )
 
-        return structure_run["output"]["value"] if "output" in structure_run else None
-    else:
-        stderr = next(
-            (log["message"] for log in logs["logs"] if log["stream"] == "stderr"),
-            None,
-        )
-        raise ValueError(stderr)
+#    if structure_run["status"] == "SUCCEEDED":
+#        stdout = next(
+#            (log["message"] for log in logs["logs"] if log["stream"] == "stdout"),
+#            None,
+#        )
+#        print(stdout)
+
+#        return structure_run["output"]["value"] if "output" in structure_run else None
+#    else:
+#        stderr = next(
+#            (log["message"] for log in logs["logs"] if log["stream"] == "stderr"),
+#            None,
+#        )
+#        raise ValueError(stderr)
 
 
 if __name__ == "__main__":

--- a/structure.py
+++ b/structure.py
@@ -63,7 +63,7 @@ def run_example_with_griptape_agent(
         event_driver (optional): the object that will publish events as the agent thinks.
     """
 
-    structure = Agent(tools=[CalculatorTool(off_prompt=False)])
+    structure = Agent(stream=True, tools=[CalculatorTool(off_prompt=False)])
 
     structure.run(input)
 


### PR DESCRIPTION
This update reduces the amount of boilerplate for customers to handle when invoking a structure and provides them a method to use only an eventing system. It eliminates the need for them to poll both Structure Run Status AND the Structure Run events. Customers who want to rely on Structure Run resource Status can still do so.

Assumptions: This draft assumes that Structure Runs are amended to inject System Events for when a Structure Run...
1. ...starts execution (i.e., gets out of QUEUED state)
1. ...stops executing customer code with errors
1. ...stops executing customer code withOUT errors

Open Questions:
1. Can the Events API be amended to take an optional parameter for where to start? This would allow clients to only request the events that occured since the most recent one they received and reduce bandwidth.
2. Do we want to change the name of the `FinishStructureRunEvent` to be clearer it is an OPTIONAL signal from the Structure code to let the client know that it is, from the client's POV, done and has a payload ready for them?
3. How do we want to signify the System Events?
4. In the mainline version we have the client requesting logs, but these can take several minutes against a real world situation. Can we embed the log info into the structure completion events?