### PR TITLE
Client Use SSE Events

### DIFF
--- a/example-client/pyproject.toml
+++ b/example-client/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = ""
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
Refactors client to use Cloud's server sent events, `/events/stream`, instead of polling `/events`.

Closes #21 